### PR TITLE
refactor: do not explicitly exit from pack.bat

### DIFF
--- a/pack.bat
+++ b/pack.bat
@@ -31,5 +31,3 @@ rmdir ..\temp\ /S /Q
 rmdir Bootup_USen\ /S /Q
 rmdir Bootup_EUen\ /S /Q
 explorer ..\!output
-
-exit


### PR DESCRIPTION
Double-clicking on the script will automatically exit at the end, but it's not expected behaviour that running the script from the command line will exit the whole prompt.